### PR TITLE
Create groupby data using dask

### DIFF
--- a/scripts/create_groupby_data_dask.py
+++ b/scripts/create_groupby_data_dask.py
@@ -1,0 +1,88 @@
+import numpy as np
+import pandas as pd
+from dask.distributed import Client
+import os 
+
+from argparse import ArgumentParser
+
+def read_inputs():
+    """
+    Parse command-line arguments to run create_groupby_data.
+    User should provide:
+    -N : int | float, 
+        Number of rows of the dataframe
+    -K : int | float
+        Number of groups 
+    -nfiles : int
+        Number of output files
+    -output_dir : str, 
+        Output directory.
+    """
+
+    parser = ArgumentParser(description="Manage create_groupby_data command line arguments")
+
+
+    parser.add_argument('-n', '--N', dest='N', type=float, default=None,
+                        help="Total number fo rows")
+
+    parser.add_argument('-k', '--K', dest='K', type=float, default=None,
+                        help="Number of groups")
+
+    parser.add_argument('-nf', '--nfiles', dest='nfiles', type=int, default=None,
+                        help="Number of output files")
+
+    parser.add_argument('-dir', '--output_dir', dest='dir', type=str, default='',
+                        help="Output directory")
+    
+
+    return parser.parse_args()
+
+
+def create_single_df(N, K, nfiles, i, dir):
+    
+    nrows = int(N/nfiles)
+    
+    sample_id12 = [f"id{str(x).zfill(3)}" for x in range(1, K+1)]
+    sample_id3 = [f"id{str(x).zfill(10)}" for x in range(1, int(N/K) + 1)]
+
+    id1 = np.random.choice(sample_id12, size=nrows, replace=True)
+    id2 = np.random.choice(sample_id12, size=nrows, replace=True)
+    id3 = np.random.choice(sample_id3, size=nrows, replace=True)
+    id4 = np.random.choice(K, size=nrows, replace=True)
+    id5 = np.random.choice(K, size=nrows, replace=True)
+    id6 = np.random.choice(int(N/K), size=nrows, replace=True)
+    v1 = np.random.choice(5, size=nrows, replace=True)
+    v2 = np.random.choice(15, size=nrows, replace=True)
+    v3 = np.random.uniform(0, 100, size=nrows)
+
+    df = pd.DataFrame(dict(zip([f'id{x}' for x in range(1, 7)] + ['v1', 'v2', 'v3'], 
+                               [id1, id2, id3, id4, id5, id6, v1, v2, v3])))
+
+
+    df.to_csv(f"{dir}/groupby-N_{N}_K_{K}_file_{i}.csv", index=False,
+    float_format='{:.6f}'.format)
+
+if __name__ == "__main__":
+    
+    args = read_inputs()
+
+    N  = int(args.N)
+    K  = int(args.K)
+    nfiles = args.nfiles
+    dir  = args.dir
+    i = range(nfiles)
+    
+    check_dir = os.path.isdir(dir)
+
+    if not check_dir:
+        os.makedirs(dir)
+        print(f"The directory {dir} was created and data will be at {os.path.realpath(dir)}")
+    else: 
+        print(f"The data will be located at {os.path.realpath(dir)}")
+
+    client = Client() 
+
+    client.map(lambda i: create_single_df(N, K, nfiles, i, dir), range(nfiles))
+
+
+

--- a/scripts/create_groupby_data_dask.py
+++ b/scripts/create_groupby_data_dask.py
@@ -1,88 +1,111 @@
 import numpy as np
 import pandas as pd
 from dask.distributed import Client
-import os 
+import os
 
 from argparse import ArgumentParser
+
 
 def read_inputs():
     """
     Parse command-line arguments to run create_groupby_data.
     User should provide:
-    -N : int | float, 
+    -N : int | float,
         Number of rows of the dataframe
     -K : int | float
-        Number of groups 
+        Number of groups
     -nfiles : int
         Number of output files
-    -output_dir : str, 
+    -output_dir : str,
         Output directory.
     """
 
-    parser = ArgumentParser(description="Manage create_groupby_data command line arguments")
+    parser = ArgumentParser(
+        description="Manage create_groupby_data command line arguments"
+    )
 
+    parser.add_argument(
+        "-n", "--N", dest="N", type=float, default=None, help="Total number fo rows"
+    )
 
-    parser.add_argument('-n', '--N', dest='N', type=float, default=None,
-                        help="Total number fo rows")
+    parser.add_argument(
+        "-k", "--K", dest="K", type=float, default=None, help="Number of groups"
+    )
 
-    parser.add_argument('-k', '--K', dest='K', type=float, default=None,
-                        help="Number of groups")
+    parser.add_argument(
+        "-nf",
+        "--nfiles",
+        dest="nfiles",
+        type=int,
+        default=None,
+        help="Number of output files",
+    )
 
-    parser.add_argument('-nf', '--nfiles', dest='nfiles', type=int, default=None,
-                        help="Number of output files")
-
-    parser.add_argument('-dir', '--output_dir', dest='dir', type=str, default='',
-                        help="Output directory")
-    
+    parser.add_argument(
+        "-dir",
+        "--output_dir",
+        dest="dir",
+        type=str,
+        default="",
+        help="Output directory",
+    )
 
     return parser.parse_args()
 
 
 def create_single_df(N, K, nfiles, i, dir):
-    
-    nrows = int(N/nfiles)
-    
-    sample_id12 = [f"id{str(x).zfill(3)}" for x in range(1, K+1)]
-    sample_id3 = [f"id{str(x).zfill(10)}" for x in range(1, int(N/K) + 1)]
+
+    nrows = int(N / nfiles)
+
+    sample_id12 = [f"id{str(x).zfill(3)}" for x in range(1, K + 1)]
+    sample_id3 = [f"id{str(x).zfill(10)}" for x in range(1, int(N / K) + 1)]
 
     id1 = np.random.choice(sample_id12, size=nrows, replace=True)
     id2 = np.random.choice(sample_id12, size=nrows, replace=True)
     id3 = np.random.choice(sample_id3, size=nrows, replace=True)
     id4 = np.random.choice(K, size=nrows, replace=True)
     id5 = np.random.choice(K, size=nrows, replace=True)
-    id6 = np.random.choice(int(N/K), size=nrows, replace=True)
+    id6 = np.random.choice(int(N / K), size=nrows, replace=True)
     v1 = np.random.choice(5, size=nrows, replace=True)
     v2 = np.random.choice(15, size=nrows, replace=True)
     v3 = np.random.uniform(0, 100, size=nrows)
 
-    df = pd.DataFrame(dict(zip([f'id{x}' for x in range(1, 7)] + ['v1', 'v2', 'v3'], 
-                               [id1, id2, id3, id4, id5, id6, v1, v2, v3])))
+    df = pd.DataFrame(
+        dict(
+            zip(
+                [f"id{x}" for x in range(1, 7)] + ["v1", "v2", "v3"],
+                [id1, id2, id3, id4, id5, id6, v1, v2, v3],
+            )
+        )
+    )
 
+    df.to_csv(
+        f"{dir}/groupby-N_{N}_K_{K}_file_{i}.csv",
+        index=False,
+        float_format="{:.6f}".format,
+    )
 
-    df.to_csv(f"{dir}/groupby-N_{N}_K_{K}_file_{i}.csv", index=False,
-    float_format='{:.6f}'.format)
 
 if __name__ == "__main__":
-    
+
     args = read_inputs()
 
-    N  = int(args.N)
-    K  = int(args.K)
+    N = int(args.N)
+    K = int(args.K)
     nfiles = args.nfiles
-    dir  = args.dir
+    dir = args.dir
     i = range(nfiles)
-    
+
     check_dir = os.path.isdir(dir)
 
     if not check_dir:
         os.makedirs(dir)
-        print(f"The directory {dir} was created and data will be at {os.path.realpath(dir)}")
-    else: 
+        print(
+            f"The directory {dir} was created and data will be at {os.path.realpath(dir)}"
+        )
+    else:
         print(f"The data will be located at {os.path.realpath(dir)}")
 
-    client = Client() 
+    client = Client()
 
     client.map(lambda i: create_single_df(N, K, nfiles, i, dir), range(nfiles))
-
-
-


### PR DESCRIPTION
This is a PR that adds a script to create the groupby data (no NAs and random) that uses dask. This will run the creation in parallel using the cores available on your machine. 

To run the script you need to pass args, you can check the helper to get descriptions of the args as well the corresponding flags. 

`python create_groupby_data_dask.py -h`

An example of how to use it to would be 
`python create_groupby_data_dask.py -n 1e6 -k 1e2 -nfiles 10 -dir test`

I wasn't sure to replace the create_groupby_data that you already have as there are other scripts in the repo that use it, but you can adapt them later on. 